### PR TITLE
pd.Series(np.nan, ...) -> pd.Series("", ...)

### DIFF
--- a/pandastable/core.py
+++ b/pandastable/core.py
@@ -610,7 +610,7 @@ class Table(Canvas):
         colnames = df.columns[cols]
         for c in colnames:
             if c not in rc.columns:
-                rc[c] = pd.Series(np.nan,index=df.index)
+                rc[c] = pd.Series("",index=df.index)
             #rc[c][idx] = clr
             rc.at[idx,c] = clr
         self.redraw()


### PR DESCRIPTION
pt.setRowsColours() raised ValueError: Could not convert str to float.
to tackle that a simple change in the pandastable\core.py file line 613:
creating a pandas Series filled with empty string.