### PR TITLE
hardcoding font color to black for tooltips

### DIFF
--- a/pandastable/dialogs.py
+++ b/pandastable/dialogs.py
@@ -437,7 +437,7 @@ class ToolTip(object):
             pass
         label = Label(tw, text=self.text, justify=LEFT,
                       background="#ffffe0", relief=SOLID, borderwidth=1,
-                      font=("tahoma", "8", "normal"))
+                      font=("tahoma", "8", "normal"), foreground='black')
         label.pack(ipadx=1)
 
     def hidetip(self, event=None):


### PR DESCRIPTION
otherwise label is not visible if textcolor is changed to a light one
(tooltip background is hardcoded)