### PR TITLE
adjustColumnWidths check for column name

### DIFF
--- a/pandastable/core.py
+++ b/pandastable/core.py
@@ -764,11 +764,12 @@ class Table(Canvas):
         self.redraw()
         return
 
-    def adjustColumnWidths(self, limit=30):
+    def adjustColumnWidths(self, limit=30, max_cell_width=20):
         """Optimally adjust col widths to accomodate the longest entry \
             in each column - usually only called on first redraw.
         Args:
             limit: max number of columns to resize
+            max_cell_width: maximum cell size
         """
 
         fontsize = self.fontsize
@@ -785,7 +786,7 @@ class Table(Canvas):
                     continue
             else:
                 w = self.cellwidth
-            l = self.model.getlongestEntry(col)
+            l = max(self.model.getlongestEntry(col), len(colname), max_cell_width)
             txt = ''.join(['X' for i in range(l+1)])
             tw,tl = util.getTextLength(txt, self.maxcellwidth,
                                        font=self.thefont)


### PR DESCRIPTION
adjustColumnWidths method scales based on column values only. 
In a case where column names are long but values are short, adjusting doesn't work as expected.

The fix simply adds a check and takes the max between column name length and longest entry.

Effect: 
![image](https://github.com/dmnfarrell/pandastable/assets/106302826/482a8a26-62eb-4426-8090-7f1e2e8fdfa5)
![image](https://github.com/dmnfarrell/pandastable/assets/106302826/bf2eb88c-55a2-49b9-af7f-1c2c6d8f0b12)
