### PR TITLE
Mouse wheel works in Macos and columns are properly hidden when columnwidth is set to 0 

### DIFF
--- a/pandastable/core.py
+++ b/pandastable/core.py
@@ -218,12 +218,12 @@ class Table(Canvas):
         return
 
     def mouse_wheel(self, event):
-        """Handle mouse wheel scroll for windows"""
+        """Handle mouse wheel scroll for windows and mac (darwin)"""
 
-        if event.num == 5 or event.delta == -120:
+        if event.num == 5 or event.delta == -120 or (self.ostyp == "darwin" and event.delta == -1):
             event.widget.yview_scroll(1, UNITS)
             self.rowheader.yview_scroll(1, UNITS)
-        if event.num == 4 or event.delta == 120:
+        if event.num == 4 or event.delta == 120 or (self.ostyp == "darwin" and event.delta == 1):
             if self.canvasy(0) < 0:
                 return
             event.widget.yview_scroll(-1, UNITS)

--- a/pandastable/headers.py
+++ b/pandastable/headers.py
@@ -166,7 +166,7 @@ class ColumnHeader(Canvas):
                     w = self.table.cellwidth
 
                 if w<=8:
-                    colname=''
+                    colstr=''       # correct variable allowing hidding columns
                 x = self.table.col_positions[col]
                 if anchor in ['w','nw']:
                     xt = x+pad


### PR DESCRIPTION
core.py: mouse_wheel now works for mac
headers.py: error fixed in column header (column name is correctly set to "" when columnwidth is too small). Therefore when columnwith is set to 0 column (both data and header) is properly hidden